### PR TITLE
Modification to editor and language breakdown

### DIFF
--- a/src/job-summary.ts
+++ b/src/job-summary.ts
@@ -20,7 +20,7 @@ const groupBreakdown = (key: string, data: CopilotUsageResponse, sort?: (a: [str
         acc[breakdownItem[key]].acceptances_count += breakdownItem.acceptances_count;
         acc[breakdownItem[key]].lines_suggested += breakdownItem.lines_suggested;
         acc[breakdownItem[key]].lines_accepted += breakdownItem.lines_accepted;
-        acc[breakdownItem[key]].active_users += breakdownItem.active_users;
+        acc[breakdownItem[key]].active_users = Math.max(acc[breakdownItem[key]].active_users, breakdownItem.active_users);
       } else {
         acc[breakdownItem[key]] = {
           language: breakdownItem.language.replace(/-/g, '&#8209;'),


### PR DESCRIPTION
When aggregating active user data in the tables for editor and language breakdown, customers may observe an higher number of total assigned users within the organization. To address this issue, proposal is to use the maximum active user count rather than summing these values, thereby providing a more accurate representation of the data.